### PR TITLE
Set COMPOSER_HOME at once downloadComposer() is called.

### DIFF
--- a/composer/main.php
+++ b/composer/main.php
@@ -20,6 +20,7 @@ function getStatus()
 
 function downloadComposer()
 {
+    putenv('COMPOSER_HOME=' . __DIR__);
     $installerURL = 'https://getcomposer.org/installer';
     $installerFile = 'installer.php';
     if (!file_exists($installerFile))


### PR DESCRIPTION
COMPOSER_HOME has not been set by default. Calling downloadComposer() will be failed unless you set COMPOSER_HOME.
